### PR TITLE
Update Julia version to 1.12.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -60,7 +60,7 @@ StatsBase = "0.34.5"
 StatsModels = "0.7.4"
 Suppressor = "0.2.8"
 UnicodePlots = "3.7.1"
-julia = "1.12"
+julia = "1.12.2"
 
 [extras]
 CUDA_Runtime_jll = "76a88914-d11a-5bdc-97e0-2f5a05c973a2"


### PR DESCRIPTION
Updated Julia version from 1.12 to 1.12.2 in Project.toml. To test if the precompilation error of MLDataDevices persists.